### PR TITLE
Unwatch unique queries same path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-redux-firebase",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "Redux integration for Firebase. Comes with a Higher Order Component for use with React.",
   "browser": "dist/react-redux-firebase.js",
   "main": "lib/index.js",

--- a/src/actions/query.js
+++ b/src/actions/query.js
@@ -193,7 +193,7 @@ export const watchEvents = (firebase, dispatch, events) =>
  */
 export const unWatchEvents = (firebase, dispatch, events) =>
     events.forEach(event =>
-      unWatchEvent(firebase, dispatch, event.type, event.path)
+      unWatchEvent(firebase, dispatch, event.type, event.path, event.queryId)
     )
 
 export default { watchEvents, unWatchEvents }


### PR DESCRIPTION
### Description
When multiple listeners are set on the same path with different query parameters, all of the paths are not correctly unwatched when the component unmounts.

Passing queryId into the unWatchEvent function is necessary for
unique queries on the same base path to be properly identified when
unwatching events.  getQueryIdFromPath and getWatchPath do not
correctly identify unique queries at the same path (because the path
that is passed into these functions is the path without query strings
attached).  This scenario happens when using storeAs functionality.

### Check List
If not relevant to pull request, check off as complete

- [X ] All tests passing (except one test that was failing prior to this PR)
- [NA] Docs updated with any changes or examples if applicable
- [NA ] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
Closes #234